### PR TITLE
fix: unescape text in MdRenderer

### DIFF
--- a/packages/topotal-ui/src/components/MdRenderer/components/Code/index.tsx
+++ b/packages/topotal-ui/src/components/MdRenderer/components/Code/index.tsx
@@ -25,4 +25,4 @@ const Code: React.FC<Props> = ({
   )
 }
 
-export default Code
+export default React.memo(Code)

--- a/packages/topotal-ui/src/components/MdRenderer/components/Heading/index.tsx
+++ b/packages/topotal-ui/src/components/MdRenderer/components/Heading/index.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react'
 import { StyleProp, TextStyle } from 'react-native'
 import { Tokens } from 'marked'
 import Text from '../../../Text'
+import { unescapeHTML } from '../../utils'
 
 type Props = {
   token: Tokens.Heading
@@ -26,7 +27,7 @@ const Heading: React.FC<Props> = ({
       type={type}
       weight="bold"
     >
-      {token.text}
+      {unescapeHTML(token.text)}
     </Text>
   )
 }

--- a/packages/topotal-ui/src/components/MdRenderer/components/Link/index.tsx
+++ b/packages/topotal-ui/src/components/MdRenderer/components/Link/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Tokens } from 'marked'
 import Text from '../../../Text'
+import { unescapeHTML } from '../../utils'
 import { useStyles } from './styles'
 
 type Props = {
@@ -23,9 +24,9 @@ const Link: React.FC<Props> = ({
       accessibilityRole="link"
       {...anchorAttributes}
     >
-      {token.text}
+      {unescapeHTML(token.text)}
     </Text>
   )
 }
 
-export default Link
+export default React.memo(Link)

--- a/packages/topotal-ui/src/components/MdRenderer/components/Paragraph/index.tsx
+++ b/packages/topotal-ui/src/components/MdRenderer/components/Paragraph/index.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react'
 import { StyleProp, TextStyle } from 'react-native'
 import { Tokens } from 'marked'
-import { normalizeTokens } from '../../utils'
+import { normalizeTokens, unescapeHTML } from '../../utils'
 import Text from '../../../Text'
 import Strong from '../Strong'
 import Link from '../Link'
@@ -25,7 +25,7 @@ const Paragraph: React.FC<Props> = ({
       {tokens.map((token, index) => {
         switch (token.type) {
           case 'text':
-            return token.text
+            return unescapeHTML(token.text)
           case 'strong':
             return <Strong key={index} token={token} />
           case 'link':

--- a/packages/topotal-ui/src/components/MdRenderer/components/Strong/index.tsx
+++ b/packages/topotal-ui/src/components/MdRenderer/components/Strong/index.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { StyleProp, TextStyle } from 'react-native'
 import { Tokens } from 'marked'
 import Text from '../../../Text'
+import { unescapeHTML } from '../../utils'
 
 type Props = {
   token: Tokens.Strong
@@ -14,9 +15,9 @@ const Strong: React.FC<Props> = ({
 }) => {
   return (
     <Text style={style} weight="bold">
-      {token.text}
+      {unescapeHTML(token.text)}
     </Text>
   )
 }
 
-export default Strong
+export default React.memo(Strong)

--- a/packages/topotal-ui/src/components/MdRenderer/index.stories.tsx
+++ b/packages/topotal-ui/src/components/MdRenderer/index.stories.tsx
@@ -12,6 +12,8 @@ text text
 
 text in [link](https://google.com).
 
+let's
+
 **Bold text**
 
 ### h3

--- a/packages/topotal-ui/src/components/MdRenderer/utils.ts
+++ b/packages/topotal-ui/src/components/MdRenderer/utils.ts
@@ -17,3 +17,8 @@ export const normalizeTokens = (tokens: Token[]): NormalizedToken[] => {
     return true
   }) as NormalizedToken[]
 }
+
+export const unescapeHTML = (escapedHtml: string) => {
+  const doc = new DOMParser().parseFromString(escapedHtml, 'text/html')
+  return doc.documentElement.textContent || ''
+}


### PR DESCRIPTION
## What
`'` などがエスケープされてしまっていたバグを修正