### PR TITLE
fix(topotal-ui): Patch indicator size in Button

### DIFF
--- a/packages/topotal-ui/src/components/Button/index.stories.tsx
+++ b/packages/topotal-ui/src/components/Button/index.stories.tsx
@@ -47,6 +47,8 @@ export const all = () => (
       variant="text"
     />
     <Button title="送信" size="small" loading={true} />
+    <Button title="送信" size="medium" loading={true} />
+    <Button title="送信" size="large" loading={true} />
     <Button
       title="送信"
       startIconName="done"

--- a/packages/topotal-ui/src/components/Button/index.tsx
+++ b/packages/topotal-ui/src/components/Button/index.tsx
@@ -67,7 +67,10 @@ export const Button = React.memo<Props>(({
         style={styles.wrapper}
       >
         {loading ? (
-          <ActivityIndicator color={indicatorColor} />
+          <ActivityIndicator
+            color={indicatorColor}
+            style={styles.indicator}
+          />
         ) : (
           <>
             {startIconName ? (

--- a/packages/topotal-ui/src/components/Button/styles.ts
+++ b/packages/topotal-ui/src/components/Button/styles.ts
@@ -15,6 +15,7 @@ interface Props {
 
 interface Styles {
   wrapper: ViewStyle
+  indicator: ViewStyle
   title: TextStyle
   icon: ImageStyle
 }
@@ -57,6 +58,11 @@ export const useStyles = ({
       borderColor: theme.color[borderColor],
       overflow: 'hidden',
       opacity,
+    },
+    indicator: {
+      transform: [{
+        scale: size === 'small' ? 0.7 : 1,
+      }],
     },
     title: {
       textAlign: 'center',


### PR DESCRIPTION
<img width="370" alt="スクリーンショット 2021-07-01 12 21 52" src="https://user-images.githubusercontent.com/3971271/124059957-f3660180-da66-11eb-90d7-022852c39228.png">
