### PR TITLE
add: If the size props is 'small', shrink the size of down-arrow

### DIFF
--- a/packages/topotal-ui/src/components/Picker/index.tsx
+++ b/packages/topotal-ui/src/components/Picker/index.tsx
@@ -14,6 +14,8 @@ interface Props {
   onChange?: (value: string) => void
 }
 
+export type Size = InputFrameSize
+
 const arrowIconBase64 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAQAAAD9CzEMAAAAP0lEQVRYw+3U2wkAMAjAQDfP6O0K/QkUzDmA+JxJkiT/Y85D4KbArQK3UbizwB037kbhLi3uXeCeHv2fJMlGFxq+Y5MR7CqIAAAAAElFTkSuQmCC'
 
 export const Picker = Object.assign((({
@@ -27,7 +29,7 @@ export const Picker = Object.assign((({
 }: Props) => {
   const { innerValue, handleChange } = useInputValue({ value, onChange })
   const { isFocused, handleFocus, handleBlur } = useFocus()
-  const { styles } = useStyles({ hasValue: !!innerValue })
+  const { styles } = useStyles({ hasValue: !!innerValue, size })
 
   return (
     <InputFrame
@@ -52,8 +54,6 @@ export const Picker = Object.assign((({
           <View pointerEvents="none" style={styles.arrowIconWrapper}>
             <Image
               style={styles.arrowIcon}
-              width={24}
-              height={24}
               source={{ uri: arrowIconBase64 }}
             />
           </View>

--- a/packages/topotal-ui/src/components/Picker/styles.ts
+++ b/packages/topotal-ui/src/components/Picker/styles.ts
@@ -1,4 +1,5 @@
 import { ImageStyle, Platform, StyleSheet, TextStyle, ViewStyle } from 'react-native'
+import { Size } from '.'
 
 interface Styles {
   picker: TextStyle
@@ -8,9 +9,20 @@ interface Styles {
 
 interface Props {
   hasValue: boolean
+  size: Size
 }
 
-export const useStyles = ({ hasValue }: Props) => {
+const getIconSize = (size: Size) => {
+  switch (size) {
+    case 'large':
+    case 'medium':
+      return 24
+    case 'small':
+      return 16
+  }
+}
+
+export const useStyles = ({ hasValue, size }: Props) => {
   const styles = StyleSheet.create<Styles>({
     picker: {
       borderWidth: 0,
@@ -26,8 +38,8 @@ export const useStyles = ({ hasValue }: Props) => {
       right: 8,
     },
     arrowIcon: {
-      width: 24,
-      height: 24,
+      width: getIconSize(size),
+      height: getIconSize(size),
     },
   })
 


### PR DESCRIPTION
Resolve: #181 

`<Image>` の width と height、ぱっと見の挙動（見た目の大きさ・`<img width height>` になるわけではないとか）からいらない？と思い消したのですが影響ありますでしょーか...？？