### PR TITLE
fix: textarea bug

### DIFF
--- a/packages/topotal-ui/src/components/TextArea/index.stories.tsx
+++ b/packages/topotal-ui/src/components/TextArea/index.stories.tsx
@@ -33,10 +33,12 @@ const completionItems: TextAreaCompletionItem[] = [
 export const Completion = () => {
   const [showCompletion, setShowCompletion] = useState(false)
   const ref = useRef<TextInput | null>(null)
+  const [value, setValue] = useState('')
 
   return (
     <TextArea
       ref={ref}
+      value={value}
       completionView={showCompletion ? (
         <View>
           {completionItems.map((item) => (
@@ -55,11 +57,15 @@ export const Completion = () => {
         } else {
           setShowCompletion(false)
         }
+        setValue(text)
       }}
       onKeyPress={(event: NativeSyntheticEvent<TextInputKeyPressEventData>) => {
         if (event.nativeEvent.key === 'Enter') {
           event.preventDefault()
-          console.info((event.target as any).setRangeText('test', 2, 3))
+          setValue(value + 'hoge')
+          setTimeout(() => {
+            console.info((event.target as unknown as HTMLInputElement).setSelectionRange(0, 0))
+          }, 0)
         }
       }}
     />

--- a/packages/topotal-ui/src/components/TextArea/index.tsx
+++ b/packages/topotal-ui/src/components/TextArea/index.tsx
@@ -70,6 +70,7 @@ export const TextArea = forwardRef(({
           <BaseInput
             ref={ref}
             {...rest}
+            value={value}
             focusable={!disabled}
             autoCapitalize={autoCapitalize}
             multiline


### PR DESCRIPTION
`value` を `{...rest}` で渡せていると勘違いし記載が漏れていたので追加