### PR TITLE
Added props "onCmdEnterPress" to Inputs

### DIFF
--- a/packages/topotal-ui/src/components/TextArea/index.stories.tsx
+++ b/packages/topotal-ui/src/components/TextArea/index.stories.tsx
@@ -71,3 +71,10 @@ export const Completion = () => {
     />
   )
 }
+
+export const OnCmdEnterPress = () => (
+  <TextArea
+    onCmdEnterPress={() => console.log('command and enter pressed')}
+  />
+)
+

--- a/packages/topotal-ui/src/components/TextArea/index.stories.tsx
+++ b/packages/topotal-ui/src/components/TextArea/index.stories.tsx
@@ -72,8 +72,24 @@ export const Completion = () => {
   )
 }
 
+export const OnKeyPress= () => (
+  <TextArea
+    value="press some kind of key"
+    onKeyPress={(event) => console.log(event.nativeEvent.key)}
+  />
+)
+
 export const OnCmdEnterPress = () => (
   <TextArea
+    value="press command + enter"
+    onCmdEnterPress={() => console.log('command and enter pressed')}
+  />
+)
+
+export const OnKeyPressAndCmdEnterPress = () => (
+  <TextArea
+    value="press some kind of key or command + enter"
+    onKeyPress={(event) => console.log(event.nativeEvent.key)}
     onCmdEnterPress={() => console.log('command and enter pressed')}
   />
 )

--- a/packages/topotal-ui/src/components/TextArea/index.tsx
+++ b/packages/topotal-ui/src/components/TextArea/index.tsx
@@ -30,6 +30,7 @@ export const TextArea = forwardRef(({
   testID,
   onChangeText,
   onSelectionChange,
+  onKeyPress,
   onCmdEnterPress,
   ...rest
 }: Props, ref: ForwardedRef<TextInput>) => {
@@ -57,8 +58,11 @@ export const TextArea = forwardRef(({
 
     if((event.nativeEvent.key === 'Enter' && keyEvents.metaKey) || (key === 'Enter' && keyEvents.ctrlKey)) {
       onCmdEnterPress?.()
+      return
     }
-  }, [onCmdEnterPress])
+
+    onKeyPress?.(event)
+  }, [onCmdEnterPress, onKeyPress])
 
   useEffect(() => {
     setInnerValue(value || '')

--- a/packages/topotal-ui/src/components/TextArea/index.tsx
+++ b/packages/topotal-ui/src/components/TextArea/index.tsx
@@ -1,5 +1,5 @@
 import { ForwardedRef, forwardRef, useCallback, useEffect, useState } from 'react'
-import { NativeSyntheticEvent, TextInput as BaseInput, TextInput, TextInputSelectionChangeEventData, View } from 'react-native'
+import { NativeSyntheticEvent, TextInput as BaseInput, TextInput, TextInputKeyPressEventData, TextInputSelectionChangeEventData, View } from 'react-native'
 import { useFocus, useMeasure } from '../../hooks'
 import { InputFrame } from '../InputFrame'
 import { Text } from '../Text'
@@ -15,6 +15,7 @@ type BaseProps = {
   disabled?: boolean
   testID?: string
   completionView?: React.ReactNode
+  onCmdEnterPress?: VoidFunction
 } & Omit<React.ComponentProps<typeof BaseInput>, 'multiline' | 'editable'>
 
 type Props = BaseProps & React.RefAttributes<BaseInput>
@@ -29,6 +30,7 @@ export const TextArea = forwardRef(({
   testID,
   onChangeText,
   onSelectionChange,
+  onCmdEnterPress,
   ...rest
 }: Props, ref: ForwardedRef<TextInput>) => {
   const [innerValue, setInnerValue] = useState<string>(value || '')
@@ -48,6 +50,15 @@ export const TextArea = forwardRef(({
     setInnerValue(text)
     onChangeText?.(text)
   }, [onChangeText])
+
+  const handleKeyPress = useCallback((event: NativeSyntheticEvent<TextInputKeyPressEventData>) => {
+    const { key } = event.nativeEvent
+    const keyEvents = event.nativeEvent as any
+
+    if((event.nativeEvent.key === 'Enter' && keyEvents.metaKey) || (key === 'Enter' && keyEvents.ctrlKey)) {
+      onCmdEnterPress?.()
+    }
+  }, [onCmdEnterPress])
 
   useEffect(() => {
     setInnerValue(value || '')
@@ -79,6 +90,7 @@ export const TextArea = forwardRef(({
             onSelectionChange={handleSelectionChange}
             onFocus={handleFocus}
             onBlur={handleBlur}
+            onKeyPress={handleKeyPress}
             style={[style, styles.input]}
             testID={testID}
           />

--- a/packages/topotal-ui/src/components/TextInput/index.stories.tsx
+++ b/packages/topotal-ui/src/components/TextInput/index.stories.tsx
@@ -17,5 +17,6 @@ export const all = () => (
     <TextInput size="medium" secureTextEntry placeholder="Password"/>
     <TextInput size="medium" error />
     <TextInput size="medium" value="default value" onChangeText={value => console.info(value)}/>
+    <TextInput size="medium" onCmdEnterPress={() => console.log('command and enter pressed')}/>
   </>
 )

--- a/packages/topotal-ui/src/components/TextInput/index.stories.tsx
+++ b/packages/topotal-ui/src/components/TextInput/index.stories.tsx
@@ -17,6 +17,8 @@ export const all = () => (
     <TextInput size="medium" secureTextEntry placeholder="Password"/>
     <TextInput size="medium" error />
     <TextInput size="medium" value="default value" onChangeText={value => console.info(value)}/>
-    <TextInput size="medium" onCmdEnterPress={() => console.log('command and enter pressed')}/>
+    <TextInput size="medium" value="press some kind of key" onKeyPress={event => console.info(event.nativeEvent.key)}/>
+    <TextInput size="medium" value="press command + enter" onCmdEnterPress={() => console.log('command and enter pressed')}/>
+    <TextInput size="medium" value="press some kind of key or command + enter" onKeyPress={event => console.info(event.nativeEvent.key)} onCmdEnterPress={() => console.log('command and enter pressed')}/>
   </>
 )

--- a/packages/topotal-ui/src/components/TextInput/index.tsx
+++ b/packages/topotal-ui/src/components/TextInput/index.tsx
@@ -1,5 +1,5 @@
-import { memo, Ref } from 'react'
-import { TextInput as BaseInput } from 'react-native'
+import { memo, Ref, useCallback } from 'react'
+import { NativeSyntheticEvent, TextInput as BaseInput, TextInputKeyPressEventData } from 'react-native'
 import { useFocus, useInputValue } from '../../hooks'
 import type { InputFrameSize } from '../InputFrame'
 import { InputFrame } from '../InputFrame'
@@ -13,6 +13,7 @@ type BaseProps = {
   disabled?: boolean
   startIconName?: string
   testID?: string
+  onCmdEnterPress?: VoidFunction
 } & Omit<React.ComponentProps<typeof BaseInput>, 'multiline' | 'editable'>
 
 type Props = BaseProps & React.RefAttributes<BaseInput>
@@ -28,6 +29,7 @@ export const TextInput = memo<Props>(({
   style,
   testID,
   onChangeText,
+  onCmdEnterPress,
   ...rest
 }) => {
   const { innerValue, handleChange } = useInputValue<string>({
@@ -36,6 +38,14 @@ export const TextInput = memo<Props>(({
   })
   const { isFocused, handleFocus, handleBlur } = useFocus()
   const { styles, placeholderColor } = useStyles()
+  const handleKeyPress = useCallback((event: NativeSyntheticEvent<TextInputKeyPressEventData>) => {
+    const { key } = event.nativeEvent
+    const keyEvents = event.nativeEvent as any
+
+    if((event.nativeEvent.key === 'Enter' && keyEvents.metaKey) || (key === 'Enter' && keyEvents.ctrlKey)) {
+      onCmdEnterPress?.()
+    }
+  }, [onCmdEnterPress])
 
   return (
     <InputFrame
@@ -61,6 +71,7 @@ export const TextInput = memo<Props>(({
           onChangeText={handleChange}
           onFocus={handleFocus}
           onBlur={handleBlur}
+          onKeyPress={handleKeyPress}
           style={style}
           testID={testID}
         />

--- a/packages/topotal-ui/src/components/TextInput/index.tsx
+++ b/packages/topotal-ui/src/components/TextInput/index.tsx
@@ -28,6 +28,7 @@ export const TextInput = memo<Props>(({
   innerRef,
   style,
   testID,
+  onKeyPress,
   onChangeText,
   onCmdEnterPress,
   ...rest
@@ -44,8 +45,11 @@ export const TextInput = memo<Props>(({
 
     if((event.nativeEvent.key === 'Enter' && keyEvents.metaKey) || (key === 'Enter' && keyEvents.ctrlKey)) {
       onCmdEnterPress?.()
+      return
     }
-  }, [onCmdEnterPress])
+
+    onKeyPress?.(event)
+  }, [onCmdEnterPress, onKeyPress])
 
   return (
     <InputFrame


### PR DESCRIPTION
## やったこと
下記コンポーネントにcommand + Enterを押したときのPropsを追加しました！
- TextInput
- TextArea

## 関連issue
https://github.com/topotal/waroom-frontend/issues/138

## 気になること
> ちなみに onCmdEnterPress が渡されて無ければ、既存の onKeyPress の処理を邪魔しないような設計で書いてもらえると嬉しいです 👍🏻

この辺の文脈が実装とあっているか確認していただきたいです 🙏 

![image](https://user-images.githubusercontent.com/35086740/233774556-34b37e8c-30b1-4d54-ada1-900911eed2f8.png)
