### PR TITLE
Fix theme and build-doc

### DIFF
--- a/packages/topotal-ui/package.json
+++ b/packages/topotal-ui/package.json
@@ -31,7 +31,7 @@
     "prepublishOnly": "yarn build",
     "lint": "eslint --ext .ts,.tsx src",
     "storybook": "NODE_OPTIONS=--openssl-legacy-provider start-storybook -p 6006",
-    "build-doc": "STORYBOOK_ASSETS_PATH=/js-sdk/topotal-ui build-storybook -o ../../docs/topotal-ui/"
+    "build-doc": "NODE_OPTIONS=--openssl-legacy-provider STORYBOOK_ASSETS_PATH=/js-sdk/topotal-ui build-storybook -o ../../docs/topotal-ui/"
   },
   "dependencies": {
     "marked": "^4.0.6",

--- a/packages/topotal-ui/src/theme/index.ts
+++ b/packages/topotal-ui/src/theme/index.ts
@@ -39,7 +39,7 @@ export const defaultTheme = {
     borderDark: palette.sumi,
     cancel: '#666666',
     cancelLight: '#E5E5E5',
-    cancelDark: '#4F4F4F',
+    cancelDark: '#5E5E5E',
     primaryTextDark: palette.sumi,
     secondaryTextDark: palette.katana,
     primaryTextLight: palette.yuki,


### PR DESCRIPTION
## 関連issue
https://github.com/topotal/js-sdk/issues/373
https://github.com/topotal/js-sdk/issues/374

## やったこと
- themeの`cancelDark`のカラーコードを修正しました。
- `build-doc`がnode versionによるエラーとなっていたので修正しました。

![image](https://github.com/topotal/js-sdk/assets/35086740/ada83d87-f15e-4f12-8abf-61032316434b)
