### PR TITLE
Add props to Tags and UserIcon components

### DIFF
--- a/packages/topotal-ui/src/components/Tag/index.stories.tsx
+++ b/packages/topotal-ui/src/components/Tag/index.stories.tsx
@@ -4,6 +4,8 @@ export default {
   title: 'components/Tag',
 }
 
+const iconUrl = 'https://randomuser.me/api/portraits/men/1.jpg'
+
 export const Default = () => (
   <Tag
     tagData={{
@@ -22,3 +24,26 @@ export const WithRemoveButton = () => (
     onPressRemove={() => { console.log('onPressRemove') }}
   />
 )
+
+export const WithIcon = () => (
+  <Tag
+    tagData={{
+      label: 'leonard wagner',
+      value: 'test',
+      iconUrl,
+    }}
+  />
+)
+
+
+export const WithIconAndRemoveButton = () => (
+  <Tag
+    tagData={{
+      label: 'leonard wagner',
+      value: 'test',
+      iconUrl,
+    }}
+    onPressRemove={() => { console.log('onPressRemove') }}
+  />
+)
+

--- a/packages/topotal-ui/src/components/Tag/index.tsx
+++ b/packages/topotal-ui/src/components/Tag/index.tsx
@@ -1,11 +1,12 @@
 import { memo, useCallback } from 'react'
 import { Image, Pressable, StyleProp, ViewStyle } from 'react-native'
-import { HStack, Text } from '..'
+import { HStack, Text, UserIcon } from '..'
 import { useStyles } from './styles'
 
 export interface TagData {
   label: string
   value: string
+  iconUrl?: string
 }
 
 interface Props {
@@ -37,6 +38,9 @@ export const Tag = memo<Props>(({
         align="center"
         style={styles.container}
       >
+        {tagData.iconUrl && (
+          <UserIcon size={'extraSmall'} uri={tagData.iconUrl} />
+        )}
         <Text style={styles.label}>
           {tagData.label}
         </Text>

--- a/packages/topotal-ui/src/components/UserIcon/index.stories.tsx
+++ b/packages/topotal-ui/src/components/UserIcon/index.stories.tsx
@@ -10,6 +10,10 @@ const defaultProps: Props = {
   uri: 'https://randomuser.me/api/portraits/men/1.jpg',
 }
 
+export const ExtraSmall = () => (
+  <UserIcon {...defaultProps} size="extraSmall" />
+)
+
 export const Small = () => (
   <UserIcon {...defaultProps} size="small" />
 )

--- a/packages/topotal-ui/src/components/UserIcon/index.tsx
+++ b/packages/topotal-ui/src/components/UserIcon/index.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useState } from 'react'
 import { Image, StyleProp, View, ViewStyle } from 'react-native'
 import { useStyles } from './styles'
 
-export type UserIconSize = 'small' | 'medium' | 'large'
+export type UserIconSize = 'extraSmall' | 'small' | 'medium' | 'large'
 
 interface Props {
   uri: string

--- a/packages/topotal-ui/src/components/UserIcon/styles.ts
+++ b/packages/topotal-ui/src/components/UserIcon/styles.ts
@@ -23,6 +23,12 @@ const getDynamicStyle = (size: UserIconSize) => {
         height: 24,
         borderRadius: 12,
       }
+    case 'extraSmall':
+      return {
+        width: 18,
+        height: 18,
+        borderRadius: 10,
+      }
   }
 }
 


### PR DESCRIPTION
## 関連issue
https://github.com/topotal/waroom/issues/1134

## やったこと
- UserIconのsize propsに`extraSmall`を追加しました
- TagsのtagDataに`iconUrl`を追加して画像を表示されるようにしました。

|Tags|
|---|
|![image](https://github.com/topotal/js-sdk/assets/35086740/e5258646-d7e0-4c54-aef5-1061771759c0)|