### PR TITLE
upgrade version for react, react-native-web

### DIFF
--- a/packages/topotal-ui/package.json
+++ b/packages/topotal-ui/package.json
@@ -62,7 +62,7 @@
     "prettier": "^2.2.1",
     "react": "^18.2.0",
     "react-dom": "^17.0.1",
-    "react-native-web": "^0.18.10",
+    "react-native-web": "^0.19.6",
     "rimraf": "^3.0.2",
     "typescript": "^4.1.2"
   },


### PR DESCRIPTION
## 関連issue
https://github.com/topotal/js-sdk/issues/387

## 対応内容
react-domのバージョンを最新に上げました。
react-native-web のバージョンを最新に上げました。

## 動作確認

- yarn storybookが通り、storyが表示されること
- yarn buildが通ること
```
yarn build
yarn run v1.22.19
$ yarn clean && yarn build:lib && yarn build:esm
$ rimraf lib esm
$ tsc -p tsconfig.build.json
$ tsc -p tsconfig.esm.build.json
✨  Done in 10.29s.
```
