### PR TITLE
Fix config

### DIFF
--- a/packages/topotal-ui/tsconfig.json
+++ b/packages/topotal-ui/tsconfig.json
@@ -27,6 +27,5 @@
   "include": [
     "src/**/*.ts",
     "src/**/*.tsx",
-    "jest.config.ts"
   ]
 }


### PR DESCRIPTION
## 関連issue
https://github.com/topotal/js-sdk/issues/401

## 事象
- tsconfigにて、jestのファイルをincludeしたことによりjestファイルがモジュールの対象ファイルとなってしまった
- これによりモジュールの従来の構成が崩れ呼び出し側(waroom-frontend)がモジュールを解決できなくなってしまった

## 対応方法
tsconfigからincludeを除去し、モジュールが解決できる構成に修正しました 🙏 