### PR TITLE
Add AI Color

### DIFF
--- a/packages/topotal-ui/src/components/Button/index.stories.tsx
+++ b/packages/topotal-ui/src/components/Button/index.stories.tsx
@@ -116,5 +116,6 @@ export const All = () => (
       <Button startIconName="done" title="InnerOutline" size="medium" innerOutline variant="outline" />
       <Button endIconName="done" title="InnerOutline" size="medium" innerOutline variant="outline" />
     </VStack>
+    <Button title="ポストモーテムを生成" size="medium" color="ai" variant="outline" />
   </VStack>
 )

--- a/packages/topotal-ui/src/components/Button/styles.ts
+++ b/packages/topotal-ui/src/components/Button/styles.ts
@@ -54,8 +54,8 @@ export const useStyles = ({
     wrapper: {
       borderWidth: 1,
       borderRadius: theme.radius.level1,
-      backgroundColor: theme.color[backgroundColor],
-      borderColor: theme.color[borderColor],
+      backgroundColor: Object.keys(theme.color).includes(backgroundColor) ? theme.color[backgroundColor] : backgroundColor,
+      borderColor: Object.keys(theme.color).includes(borderColor) ? theme.color[borderColor] : borderColor,
       overflow: 'hidden',
       opacity,
       ...(Platform.OS === 'web' ? {
@@ -77,13 +77,13 @@ export const useStyles = ({
     title: {
       textAlign: 'center',
       lineHeight: height,
-      color: theme.color[fontColor],
+      color: Object.keys(theme.color).includes(fontColor) ? theme.color[fontColor] : '#BF2FE3',
       fontWeight,
     },
     icon: {
       width: iconSize,
       height: iconSize,
-      tintColor: theme.color[fontColor],
+      tintColor: Object.keys(theme.color).includes(fontColor) ? theme.color[fontColor] : '#BF2FE3',
     },
   })
 

--- a/packages/topotal-ui/src/components/Button/types.ts
+++ b/packages/topotal-ui/src/components/Button/types.ts
@@ -1,7 +1,7 @@
 import { TextType, ThemeColor } from '../../theme'
 
 export type Size = 'small' | 'medium' | 'large'
-export type Color = 'basic' | 'primary' | 'error' | 'cancel' | 'success' | 'warning'
+export type Color = 'basic' | 'primary' | 'error' | 'cancel' | 'success' | 'warning' | 'ai'
 export type Variant = 'contain' | 'outline' | 'text'
 
 export interface DynamicGeometry {

--- a/packages/topotal-ui/src/components/Button/utils.ts
+++ b/packages/topotal-ui/src/components/Button/utils.ts
@@ -40,7 +40,7 @@ export const getDynamicGeometry = (size: Size): DynamicGeometry => {
 }
 
 export const getHasColorMaterial = (
-  color: Exclude<Color, 'basic'>,
+  color: Exclude<Color, 'basic' | 'ai'>,
   variant: Variant,
   disabled: boolean,
   loading: boolean,
@@ -69,6 +69,38 @@ export const getHasColorMaterial = (
       return {
         opacity,
         backgroundColor: hovering ? darkColor : color,
+        borderColor: 'transparent',
+        fontColor: 'primaryTextLight',
+      }
+  }
+}
+
+export const getAiColorMaterial = (
+  variant: Variant,
+  disabled: boolean,
+  loading: boolean,
+): DynamicMaterial => {
+  const opacity = disabled || loading ? 0.5 : 1
+
+  switch (variant) {
+    case 'outline':
+      return {
+        opacity,
+        backgroundColor: 'transparent',
+        borderColor: '#BF2FE3' as keyof ThemeColor,
+        fontColor: '#BF2FE3' as keyof ThemeColor,
+      }
+    case 'text':
+      return {
+        opacity,
+        backgroundColor: 'transparent',
+        borderColor: 'transparent',
+        fontColor: '#BF2FE3' as keyof ThemeColor,
+      }
+    case 'contain':
+      return {
+        opacity,
+        backgroundColor: '#BF2FE3'  as keyof ThemeColor,
         borderColor: 'transparent',
         fontColor: 'primaryTextLight',
       }
@@ -122,6 +154,12 @@ export const getDynamicMaterial = (
         disabled,
         loading,
         hovering
+      )
+    case 'ai':
+      return getAiColorMaterial(
+        variant,
+        disabled,
+        loading,
       )
     default:
       return getHasColorMaterial(


### PR DESCRIPTION
## 関連issue
https://github.com/topotal/waroom-frontend/issues/1808

## やったこと
- ButtonコンポーネントにAIカラーを追加しました
  - hoverじのカラーがないため一旦`transparent`で実装しています

## 動作確認
issueにて画像を添付しています