### PR TITLE
Add Disabled Props to List component

### DIFF
--- a/packages/topotal-ui/src/components/List/components/Row/index.tsx
+++ b/packages/topotal-ui/src/components/List/components/Row/index.tsx
@@ -12,6 +12,7 @@ interface Props<T = any> {
   onHoverIn: (index: number) => void
   onHoverOut: (index: number) => void
   onPress?: (item: T) => void
+  itemDisabled?: (item: T) => boolean
 }
 
 export const Row = React.memo<Props>(({
@@ -21,14 +22,17 @@ export const Row = React.memo<Props>(({
   disabledChangeBackground = false,
   style,
   renderItem,
+  itemDisabled,
   onPress,
   onHoverIn,
   onHoverOut,
 }) => {
+  const disabled = itemDisabled?.(item) ?? false
   const { styles } = useStyles({
     firstItem: index === 0,
     hovered,
     pressable: !!onPress,
+    disabled,
   })
 
   const handlePress = useCallback(() => {
@@ -51,6 +55,7 @@ export const Row = React.memo<Props>(({
   return (
     <Pressable
       style={[styles.wrapper, style]}
+      disabled={disabled}
       onPress={handlePress}
       onHoverIn={handleHoverIn}
       onHoverOut={handleHoverOut}

--- a/packages/topotal-ui/src/components/List/components/Row/styles.ts
+++ b/packages/topotal-ui/src/components/List/components/Row/styles.ts
@@ -10,12 +10,15 @@ interface Props {
   firstItem: boolean
   hovered: boolean
   pressable: boolean
+  disabled: boolean
 }
+
 
 export const useStyles = ({
   firstItem,
   hovered,
   pressable,
+  disabled,
 }: Props) => {
   const { color } = useTheme()
 
@@ -24,6 +27,7 @@ export const useStyles = ({
       minHeight: 20,
       borderTopWidth: firstItem ? 0 : 1,
       borderColor: color.borderLight,
+      opacity: disabled ? 0.5 : 1,
       backgroundColor: hovered ? color.background : color.surface,
       cursor: pressable ? 'pointer' : 'default',
     },
@@ -34,6 +38,7 @@ export const useStyles = ({
     firstItem,
     hovered,
     pressable,
+    disabled,
   ])
 
   return {

--- a/packages/topotal-ui/src/components/List/components/Row/styles.ts
+++ b/packages/topotal-ui/src/components/List/components/Row/styles.ts
@@ -30,6 +30,7 @@ export const useStyles = ({
       opacity: disabled ? 0.5 : 1,
       backgroundColor: hovered ? color.background : color.surface,
       cursor: pressable ? 'pointer' : 'default',
+      pointerEvents: disabled ? 'none' : 'auto',
     },
   }), [
     color.background,

--- a/packages/topotal-ui/src/components/List/index.stories.tsx
+++ b/packages/topotal-ui/src/components/List/index.stories.tsx
@@ -42,6 +42,12 @@ DisabledChangeBackground.args = {
   disabledChangeBackground: true,
 }
 
+export const ItemDisabled: Story<ListProps<Item>> = Template.bind({})
+ItemDisabled.args = {
+  ...defaultProps,
+  itemDisabled: (item) => item.name === 'item2',
+}
+
 export const DefaultEmptyView: Story<ListProps<Item>> = Template.bind({})
 DefaultEmptyView.args = {
   ...defaultProps,

--- a/packages/topotal-ui/src/components/List/index.tsx
+++ b/packages/topotal-ui/src/components/List/index.tsx
@@ -13,6 +13,7 @@ export interface Props<T> {
   disabledChangeBackground?: boolean
   keyExtractor?: (item: T, index: number) => string
   onPressItem?: (item: T) => void
+  itemDisabled?: (item: T) => boolean
   testID?: string
 }
 
@@ -22,6 +23,7 @@ export const List = <T, >({
   emptyView,
   disabledChangeBackground = false,
   renderItem,
+  itemDisabled,
   keyExtractor,
   onPressItem,
   testID,
@@ -49,6 +51,7 @@ export const List = <T, >({
               index={index}
               hovered={index === hoveredIndex}
               disabledChangeBackground={disabledChangeBackground}
+              itemDisabled={itemDisabled}
               renderItem={renderItem}
               onPress={onPressItem}
               onHoverIn={handleHoverInRow}


### PR DESCRIPTION
## 関連issue
https://github.com/topotal/waroom/issues/1662

## やったこと
- ListコンポーネントにDisable Propsを追加しました
  - 見た目としては`opacity: 0.5`にしていますが、他にもっと良さそうなスタイルあれば教えて下さい

![Kapture 2024-11-13 at 17 49 38](https://github.com/user-attachments/assets/68045f24-74bd-498a-9f75-9af8b8a0f064)
